### PR TITLE
Add PolyKinds to list of extensions.

### DIFF
--- a/rank2classes/rank2classes.cabal
+++ b/rank2classes/rank2classes.cabal
@@ -1,5 +1,5 @@
 name:                rank2classes
-version:             0.1
+version:             0.1.1
 synopsis:            a mirror image of some standard type classes, with methods of rank 2 types
 description:
   A mirror image of the standard constructor type class hierarchy rooted in 'Functor', except with methods of rank 2

--- a/rank2classes/src/Rank2.hs
+++ b/rank2classes/src/Rank2.hs
@@ -5,7 +5,7 @@
 -- This will bring into scope the standard classes 'Functor', 'Applicative', 'Foldable', and 'Traversable', but with a
 -- @Rank2.@ prefix and a twist that their methods operate on a heterogenous collection. The same property is shared by
 -- the two less standard classes 'Apply' and 'Distributive'.
-{-# LANGUAGE InstanceSigs, KindSignatures, Rank2Types, ScopedTypeVariables #-}
+{-# LANGUAGE InstanceSigs, KindSignatures, Rank2Types, ScopedTypeVariables, PolyKinds #-}
 module Rank2 (
 -- * Rank 2 classes
    Functor(..), Apply(..), Applicative(..),


### PR DESCRIPTION
Added `PolyKinds` to list of extensions for module `Rank2`.

This is useful as it allows functors like this:

```
data D (t :: Bool -> *) = D (t 'True) (t 'False)

instance Rank2.Functor D where
  f <$> (D x y) = D (f x) (f y)
```

In this case, `D :: (Bool -> *) -> *`

But without `PolyKinds`, only types of kind `(* -> *) -> *` are accepted.

I also bumped the version to 0.1.1.