### PR TITLE
Split the 'Distributive' class to generalise it's kind and allow instances that require 'Traversable'

### DIFF
--- a/rank2classes/rank2classes.cabal
+++ b/rank2classes/rank2classes.cabal
@@ -1,5 +1,5 @@
 name:                rank2classes
-version:             0.1.1
+version:             0.2
 synopsis:            a mirror image of some standard type classes, with methods of rank 2 types
 description:
   A mirror image of the standard constructor type class hierarchy rooted in 'Functor', except with methods of rank 2

--- a/rank2classes/src/Rank2.hs
+++ b/rank2classes/src/Rank2.hs
@@ -87,16 +87,19 @@ class DistributiveTraversable g => Distributive g where
 distributeM :: (Distributive g, Rank1.Monad f) => f (g f) -> g f
 distributeM = distributeWith Rank1.join
 
--- | 'fmap', but traverses over it's argument
+-- | Like 'fmap', but traverses over it's argument
 fmapTraverse :: (DistributiveTraversable f, Rank1.Traversable g) => (forall a. g (t a) -> u a) -> g (f t) -> f u
 fmapTraverse f x = fmap (f . getCompose) (distributeTraversable x)
 
+-- | Like 'liftA2', but traverses over it's first argument
 liftA2Traverse1 :: (Apply f, DistributiveTraversable f, Rank1.Traversable g) => (forall a. g (t a) -> u a -> v a) -> g (f t) -> f u -> f v
 liftA2Traverse1 f x = liftA2 (f . getCompose) (distributeTraversable x)
 
+-- | Like 'liftA2', but traverses over it's second argument
 liftA2Traverse2 :: (Apply f, DistributiveTraversable f, Rank1.Traversable g) => (forall a. t a -> g (u a) -> v a) -> f t -> g (f u) -> f v
 liftA2Traverse2 f x y = liftA2 (\x' y' -> f x' (getCompose y')) x (distributeTraversable y)
 
+-- | Like 'liftA2', but traverses over both it's arguments
 liftA2TraverseBoth :: (Apply f, DistributiveTraversable f, Rank1.Traversable g1, Rank1.Traversable g2) => (forall a. g1 (t a) -> g2 (u a) -> v a) -> g1 (f t) -> g2 (f u) -> f v
 liftA2TraverseBoth f x y = liftA2 (\x' y' -> f (getCompose x') (getCompose y')) (distributeTraversable x) (distributeTraversable y)
 


### PR DESCRIPTION
This pull request is bit less innocuous that the last one. But I'll try to walk you through it.

For my datatype, I can almost implement `distribute`. Here's the signature of `distribute`:

`distribute :: Rank1.Functor f1 => f1 (g f2) -> g (Compose f1 f2)`

But there's two problems:

1. `distributeM :: Rank1.Monad f => f (g f) -> g f` forces kind `(* -> *) -> *` but my type is of kind `(k -> *) -> *`.
2. My datatype is similar to a Rank-2 version of [what's in this StackOverflow question](https://stackoverflow.com/questions/45025898/pushing-a-functor-into-a-tuple/45026684#45026684), just like the answer to that question suggests, I need the argument to `distributeWith` to be `Traversable`, not just a `Functor`. 

So to solve point 1, I've moved `distributeM` into a new class `DistributiveM`, which has `Distributive` as a superclass, and defined the appropriate instances. Now the kind of `Distributive` is more general.

To solve point 2, I've created a class `DistributiveTraversable`, that has all the functions of `Distributive`, but with a `Traversable` constraint. `DistributiveTraversable` is now made a superclass of `Distributive`, as if you've got an implementation of `Distributive` you have a implementation of `DistributiveTraversable`, as every `Functor` is a `Traversable`. Indeed, I've defined a default methods that allow an empty instance declaration for `DistributiveTraversable` if `Distributive` is defined. 

I've bumped the version number to 0.2 as this is not a backward compatible change. Code that just calls the functions will be fine as they all have the same names as previously, but instances will have to be added for the two new classes. The upgrade path involves the following for each existing instance:

1. Writing an empty instance for `DistributiveTraversable`. 
2. Creating an instance for `DistributiveM`.
3. Moving the definition of `distributeM` from `Distributive` to `DistributiveM`.

I understand if you're not a fan of this as it breaks backwards compatibility and complicates things a bit, so if you don't want to integrate something like this just say and I'll fork my version off.