### PR TITLE
Fix deriveFunctor for record fields with concrete types

### DIFF
--- a/rank2classes/src/Rank2/TH.hs
+++ b/rank2classes/src/Rank2/TH.hs
@@ -132,7 +132,7 @@ genFmapClause (RecC name fields) = do
                 | ty == VarT typeVar -> fieldExp fieldName [| $(varE f) ($(varE fieldName) $(varE x)) |]
              AppT _ ty
                 | ty == VarT typeVar -> fieldExp fieldName [| Rank2.fmap $(varE f) ($(varE fieldName) $(varE x)) |]
-             _ -> fieldExp fieldName [| $(varE x) |]
+             _ -> fieldExp fieldName [| $(varE fieldName) $(varE x) |]
    clause [varP f, varP x] body []
 
 genLiftA2Clause :: Con -> Q Clause


### PR DESCRIPTION
The record instance generated by:
```haskell
data Record f = Record { recordInt :: f Int, recordDouble :: Double }
deriveFunctor ''Record
```
Fails with:
```
error:
    • Couldn't match expected type ‘Double’
                  with actual type ‘Record p’
    • In the ‘recordDouble’ field of a record
      In the expression:
        Record {recordInt = f (recordInt x), recordDouble = x}
      In an equation for ‘<$>’:
          (<$>) f x
            = Record {recordInt = f (recordInt x), recordDouble = x}
    • Relevant bindings include
        x :: Record p
        f :: forall a. p a -> q a
        (<$>) :: (forall a. p a -> q a) -> Record p -> Record q
```

Line of interest:

```haskell
f <$> x = Record { recordInt = f (recordInt x), recordDouble = x }
```

This PR fixes the generation of the fmap function to correctly call the record accessor:

```haskell
f <$> x = Record { recordInt = f (recordInt x), recordDouble = recordDouble x }
```