### PR TITLE
add use-template-haskell flag

### DIFF
--- a/rank2classes/rank2classes.cabal
+++ b/rank2classes/rank2classes.cabal
@@ -22,18 +22,26 @@ source-repository head
   type:              git
   location:          https://github.com/blamario/grampa
 
+flag use-template-haskell
+  description: Enable the compilation of the Rank2.TH module
+  default: True
+  manual: True
+
 library
   hs-source-dirs:      src
-  exposed-modules:     Rank2, Rank2.TH
+  exposed-modules:     Rank2
   default-language:    Haskell2010
   -- other-modules:
   ghc-options:         -Wall
   build-depends:       base >=4.9 && <5,
-                       template-haskell >= 2.11 && < 2.14,
                        transformers >= 0.5 && < 0.6,
                        distributive == 0.5.*
   -- hs-source-dirs:      
   default-language:    Haskell2010
+
+  if flag(use-template-haskell)
+    build-depends: template-haskell >= 2.11 && < 2.14
+    exposed-modules: Rank2.TH
 
 test-suite doctests
   type:                exitcode-stdio-1.0
@@ -44,6 +52,8 @@ test-suite doctests
   build-depends:       base, rank2classes, doctest >= 0.8
 
 test-suite TH
+  if !flag(use-template-haskell)
+    buildable: False
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   default-language:    Haskell2010


### PR DESCRIPTION
hello! I'd like to use this library (thanks for writing it!) in an environment without template haskell support, specifically ARM cross compilation. This PR adds a `use-template-haskell` flag to the cabal file, defaulting to True, which when False suppresses building of `Rank2.TH` and dependence on the `template-haskell` package.