### PR TITLE
Add `Flip` to exports from Rank2

### DIFF
--- a/rank2classes/src/Rank2.hs
+++ b/rank2classes/src/Rank2.hs
@@ -12,7 +12,7 @@ module Rank2 (
    Functor(..), Apply(..), Applicative(..),
    Foldable(..), Traversable(..), Distributive(..), DistributiveTraversable(..), distributeJoin,
 -- * Rank 2 data types
-   Compose(..), Empty(..), Only(..), Identity(..), Product(..), Sum(..), Arrow(..), type (~>),
+   Compose(..), Empty(..), Only(..), Flip(..), Identity(..), Product(..), Sum(..), Arrow(..), type (~>),
 -- * Method synonyms and helper functions
    fst, snd, ap, fmap, liftA4, liftA5,
    fmapTraverse, liftA2Traverse1, liftA2Traverse2, liftA2TraverseBoth,

--- a/rank2classes/src/Rank2.hs
+++ b/rank2classes/src/Rank2.hs
@@ -170,7 +170,8 @@ newtype Only a f = Only {fromOnly :: f a} deriving (Eq, Ord, Show)
 -- | Equivalent of 'Data.Functor.Identity' for rank 2 data types
 newtype Identity g f = Identity {runIdentity :: g f} deriving (Eq, Ord, Show)
 
-newtype Flip g a f = Flip (g (f a)) deriving (Eq, Ord, Show)
+-- | A nested parametric type represented as a rank-2 type
+newtype Flip g a f = Flip {unFlip :: g (f a)} deriving (Eq, Ord, Show)
 
 instance Semigroup (g (f a)) => Semigroup (Flip g a f) where
    Flip x <> Flip y = Flip (x <> y)


### PR DESCRIPTION
I wrote these 2 commits some time ago and forgot to submit a pull request.

The first time I used rank2classes I found myself reimplementing the `Flip` type, and had originally forked this repository in order to add it. But I found it already existed unexported. This pull request adds it to the export list, and adds a haddock comment (which may be somewhat biased by what I was using the type for)