### PR TITLE
Relax checkers upper bound; add README to other-modules

### DIFF
--- a/grammatical-parsers/grammatical-parsers.cabal
+++ b/grammatical-parsers/grammatical-parsers.cabal
@@ -60,7 +60,7 @@ test-suite           quicktests
   build-depends:     base >=4.9 && < 5, containers >= 0.5.7.0 && < 0.7,
                      monoid-subclasses < 1.1, parsers < 0.13,
                      rank2classes >= 1.0.2 && < 1.4, grammatical-parsers,
-                     QuickCheck >= 2 && < 3, checkers >= 0.4.6 && < 0.5, size-based < 0.2,
+                     QuickCheck >= 2 && < 3, checkers >= 0.4.6 && < 0.6, size-based < 0.2,
                      testing-feat >= 1.1 && < 1.2,
                      tasty >= 0.7, tasty-quickcheck >= 0.7
   main-is:           Test.hs


### PR DESCRIPTION
Checkers released a new version, and relaxing the upper bound seems to work.
The tests fail on nixos because the README doesn't get found, so I tried adding that to the cabal file.